### PR TITLE
Fix `const` errors in latest build

### DIFF
--- a/include/mgos_captive_portal_wifi_setup.h
+++ b/include/mgos_captive_portal_wifi_setup.h
@@ -22,7 +22,7 @@
 #include <mgos.h>
 #include "mgos_event.h"
 
-typedef void (*wifi_setup_test_cb_t)(bool result, char *ssid, char* password, void *userdata);
+typedef void (*wifi_setup_test_cb_t)(bool result, const char *ssid, const char* password, void *userdata);
 
 #define MGOS_CAPTIVE_PORTAL_WIFI_SETUP_EV_BASE MGOS_EVENT_BASE('C', 'P', 'S')
 

--- a/mos.yml
+++ b/mos.yml
@@ -1,7 +1,7 @@
 author: Myles McNamara <myles@smyl.es>
 type: lib
 description: Captive Portal WiFi Setup, Configuration, and Testing Library
-version: 1.0.1
+version: 1.0.2
 # platforms: [ cc3200, cc3220, esp32, esp8266 ]
 
 sources:

--- a/src/mgos_captive_portal_wifi_setup.c
+++ b/src/mgos_captive_portal_wifi_setup.c
@@ -43,7 +43,6 @@ static void clear_timeout_vals(void){
     remove_event_handlers();
     s_connection_retries = 0;
 
-    mgos_event_trigger(MGOS_CAPTIVE_PORTAL_WIFI_SETUP_TEST_FAILED, sp_test_sta_vals);
     if( s_wifi_setup_test_cb != NULL ){
         s_wifi_setup_test_cb( false, sp_test_sta_vals->ssid, sp_test_sta_vals->pass, s_wifi_setup_test_userdata );
     }
@@ -51,6 +50,7 @@ static void clear_timeout_vals(void){
 
 static void sta_connect_timeout_timer_cb(void *arg) {
     clear_timeout_vals();
+    mgos_event_trigger(MGOS_CAPTIVE_PORTAL_WIFI_SETUP_TEST_FAILED, sp_test_sta_vals);
     LOG(LL_ERROR, ("Captive Portal WiFi Setup STA: Connect timeout"));
 
     (void) arg;


### PR DESCRIPTION
In the latest version of Mongoose OS, the `mgos_config_wifi_sta` struct in `mgos_config.h` has `const` variables which causes this library to fail while building.