### PR TITLE
Added cportal.enable flag and dns-sd library to fix build failure

### DIFF
--- a/mos.yml
+++ b/mos.yml
@@ -15,6 +15,7 @@ includes:
 
 config_schema:
   - [ "cportal", "o", {title: "Captive Portal configurations"}]
+  - [ "cportal.enable", "b", {title: "Captive Portal enable flag"}]
   - [ "cportal.setup", "o", {title: "Captive Portal WiFi Setup configurations"}]
   - [ "cportal.setup.copy", "i", 0, {title: "Copy SSID and Password to this STA ID after succesful test ( 0 - wifi.sta | 1 - wifi.sta1 | 2 - wifi.sta2 )"}]
   - [ "cportal.setup.timeout", "i", 30, {title: "Timeout, in seconds, before considering a WiFi connection test as failed"}]
@@ -24,6 +25,7 @@ config_schema:
 
 libs:
   - origin: https://github.com/mongoose-os-libs/wifi
+  - origin: https://github.com/mongoose-os-libs/dns-sd.git
 
 tags:
   - c


### PR DESCRIPTION
I tried to build the demo application (captive-portal-wifi-stack-demo), but that failed on the following error:

/data/fwbuild-volumes/2.14.0/apps/captive-portal-wifi-stack-demo/esp32/build_contexts/build_ctx_583582131/deps/captive-portal-wifi-s etup/src/mgos_captive_portal_wifi_setup.c:142:13: error: implicit declaration of function 'mgos_sys_config_set_dns_sd_enable' [-Werr or=implicit-function-declaration]                                                                                                                 mgos_sys_config_set_dns_sd_enable(true);

The proposed changes to the mos.yml file fix the errors, at least for the captive_portal_wifi_setup library.


