### PR TITLE
Fix missing protocl settings when testing network connection

### DIFF
--- a/src/mgos_captive_portal_wifi_setup.c
+++ b/src/mgos_captive_portal_wifi_setup.c
@@ -224,6 +224,7 @@ bool mgos_captive_portal_wifi_setup_test_ent(char *ssid, char *pass, char* user,
     sp_test_sta_vals->user = user;
     sp_test_sta_vals->anon_identity = user;
     sp_test_sta_vals->ca_cert = "";
+	sp_test_sta_vals->protocol = mgos_sys_config_get_wifi_sta_protocol();
     
     LOG(LL_INFO, ("Captive Portal WiFi Setup Testing SSID: %s PASS: %s USER: %s", ssid, pass, user));
 
@@ -248,6 +249,7 @@ bool mgos_captive_portal_wifi_setup_test(char *ssid, char *pass, wifi_setup_test
     sp_test_sta_vals->user = "";
     sp_test_sta_vals->anon_identity = "";
     sp_test_sta_vals->ca_cert = "";
+	sp_test_sta_vals->protocol = mgos_sys_config_get_wifi_sta_protocol();
     
     LOG(LL_INFO, ("Captive Portal WiFi Setup Testing SSID: %s PASS: %s", ssid, pass));
 


### PR DESCRIPTION
Hello, we have encountered an issue, where the ESP crashes during Wifi test due to a missing protocl setting.
This change fixes the bug.

Stacktrace:
```
#0  0x4000c547 in ?? ()
#1  0x400f61a5 in esp32_wifi_protocol_setup (ifx=ESP_IF_WIFI_STA, prot=0x0)
    at /c/David/dev/smart-homes/firmware/esp/deps/wifi/src/esp32/esp32_wifi.c:629
#2  0x400f636d in mgos_wifi_dev_sta_setup (cfg=0x3ffc837c)
    at /c/David/dev/smart-homes/firmware/esp/deps/wifi/src/esp32/esp32_wifi.c:330
#3  0x400f5745 in mgos_wifi_setup_sta (cfg=0x3ffc837c)
    at /c/David/dev/smart-homes/firmware/esp/deps/wifi/src/mgos_wifi.c:268
#4  0x400f71e7 in wifi_setup_test_start (cb=<optimized out>, 
    userdata=<optimized out>)
    at /c/David/dev/smart-homes/firmware/esp/deps/captive-portal-wifi-setup/src/mgos_captive_portal_wifi_setup.c:201
#5  0x400f7531 in mgos_captive_portal_wifi_setup_test (
    ssid=0x3ffc8c70 "ForsetiHome", pass=0x3ffc8328 "HomeSystems608804356",
    cb=0x0, userdata=0x0)
    at /c/David/dev/smart-homes/firmware/esp/deps/captive-portal-wifi-setup/src/mgos_captive_portal_wifi_setup.c:254
#6  0x400e6050 in connect_to_wifi_handler_cb (ri=0x3ffc83c4, 
    cb_arg=<optimized out>, fi=<optimized out>, args=...)
    at /c/David/dev/smart-homes/firmware/esp/src/fhs_connect_to_wifi_handler.cpp:107
#7  0x400f862d in mg_rpc_handle_request (ci=<optimized out>, 
    frame=0x3ffb5130 <mgos_task_stack+6784>, c=<optimized out>)
    at /c/David/dev/smart-homes/firmware/esp/deps/rpc-common/src/mg_rpc.c:294
#8  mg_rpc_handle_frame (c=<optimized out>, ci=<optimized out>, 
    frame=0x3ffb5130 <mgos_task_stack+6784>)
    at /c/David/dev/smart-homes/firmware/esp/deps/rpc-common/src/mg_rpc.c:413
#9  0x400f87fc in mg_rpc_ev_handler (ch=0x3ffc8c34, ev=<optimized out>, 
    ev_data=0x3ffb5130 <mgos_task_stack+6784>)
    at /c/David/dev/smart-homes/firmware/esp/deps/rpc-common/src/mg_rpc.c:497
#10 0x400f90fc in mg_rpc_channel_http_recd_parsed_frame (nc=0x3ffc82a4, 
    hm=0x3ffb5340 <mgos_task_stack+7312>, ch=0x3ffc8c34, method=..., args=...)
    at /c/David/dev/smart-homes/firmware/esp/deps/rpc-common/src/mg_rpc_channel_http.c:293
#11 0x400f953d in mgos_rpc_http_handler (nc=0x3ffc82a4, ev=<optimized out>, 
    ev_data=0x3ffb5340 <mgos_task_stack+7312>, user_data=<optimized out>)
    at /c/David/dev/smart-homes/firmware/esp/deps/rpc-common/src/mgos_rpc.c:93
#12 0x40171a55 in mg_call (nc=0x3ffc82a4, 
    ev_handler=0x400f94c4 <mgos_rpc_http_handler>, user_data=0x0, ev=100,
    ev_data=0x3ffb5340 <mgos_task_stack+7312>) at mongoose/src/mg_net.c:96
#13 0x401722be in mg_http_call_endpoint_handler (nc=0x3ffc82a4, ev=100, 
    hm=0x3ffb5340 <mgos_task_stack+7312>) at mongoose/src/mg_http.c:3114
#14 0x401729d8 in mg_http_handler2 (nc=0x3ffc82a4, ev=<optimized out>, 
    ev_data=0x3ffb5510 <mgos_task_stack+7776>, user_data=0x0,
    hm=0x3ffb5340 <mgos_task_stack+7312>) at mongoose/src/mg_http.c:920
#15 0x40172a58 in mg_http_handler (nc=0x3ffc82a4, ev=3, 
    ev_data=0x3ffb5510 <mgos_task_stack+7776>, user_data=0x0)
    at mongoose/src/mg_http.c:725
#16 0x40171a55 in mg_call (nc=0x3ffc82a4, 
    ev_handler=0x40172a48 <mg_http_handler>, user_data=0x0, ev=3,
    ev_data=0x3ffb5510 <mgos_task_stack+7776>) at mongoose/src/mg_net.c:96
#17 0x40172cd5 in mg_recv_tcp (len=1460, 
    buf=0x3ffca060 "POST /rpc/FHS.ConnectToWifi HTTP/1.1\r\nauthorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiZmhzX3VzZXIiLCJ1c2VyX2lkIjoiMmEwOWIxMDQtNWIyMy00ZGVmLThkMjktZjAwYjUwMGMwY2I3IiwiZXhwIjoxNTc"...,
    nc=<optimized out>) at mongoose/src/mg_net.c:644
#18 mg_do_recv (nc=0x3ffc82a4) at mongoose/src/mg_net.c:599
#19 0x40175bbb in mg_if_can_recv_cb (nc=0x3ffc82a4)
    at mongoose/src/mg_net.c:606
#20 mg_ev_mgr_lwip_process_signals (mgr=<optimized out>)
    at common/platforms/lwip/mg_lwip_ev_mgr.c:76
#21 0x40175bea in mg_lwip_if_poll (iface=<optimized out>, timeout_ms=0)
    at common/platforms/lwip/mg_lwip_ev_mgr.c:131
#22 0x40182a9c in mg_mgr_poll (m=0x3ffbab50 <s_mgr>, timeout_ms=0)
    at mongoose/src/mg_net.c:301
#23 0x4016d4ac in mongoose_poll (ms=0)
    at /data/tmp/mos_prebuild/tmp/cesanta/mos-libs/mongoose/src/mgos_mongoose.c:61
#24 0x400836f5 in mgos_mg_poll_cb (arg=<optimized out>)
    at /c/David/dev/smart-homes/firmware/esp/deps/freertos/src/mgos_freertos.c:101
#25 0x40083890 in mgos_task (arg=<optimized out>)
    at /c/David/dev/smart-homes/firmware/esp/deps/freertos/src/mgos_freertos.c:220
```